### PR TITLE
Fixed _fisher_sim function deprecated numpy type

### DIFF
--- a/FisherExact/Fisher.py
+++ b/FisherExact/Fisher.py
@@ -245,7 +245,7 @@ def _fisher_sim(c, replicate, seed=None, wkslimit=5000):
 
     observed = np.zeros((nr, nc), dtype=np.int32, order='F')
 
-    fact = np.zeros(wkslimit + 1, dtype=np.float, order='F')
+    fact = np.zeros(wkslimit + 1, dtype=np.float32, order='F')
 
     for it in range(replicate):
         rcont2(nrow=nr, ncol=nc, nrowt=sr, ncolt=sc, maxtot=maxtot,


### PR DESCRIPTION
The np.float type was a reference to the python float type in previous numpy versions and is now deprecated.  

It was used in the  _fisher_sim function fact variable computation and caused the program to fail when the simulate_pval parameter was set to True.

This pull request fix the issue by simply changing the type to float32